### PR TITLE
Run step to generate metadata from git for display in UI

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -29,6 +29,7 @@ jobs:
           cd stratos-src
           ln -sf ../stratos-config/custom-src .
           npm install
+          npm run store-git-metadata
           npm run customize
           npm run prebuild-ui
           cp -a . ../stratos-prebuilt
@@ -40,6 +41,7 @@ jobs:
       show_app_log: true
       environment_variables:
         SSO_LOGIN: "true"
+        SSO_OPTIONS: "nosplash,logout"
         CF_CLIENT: stratos
         CF_CLIENT_SECRET: ((stratos-client-secret-staging))
   on_failure:
@@ -82,6 +84,7 @@ jobs:
       show_app_log: true
       environment_variables:
         SSO_LOGIN: "true"
+        SSO_OPTIONS: "nosplash,logout"
         CF_CLIENT: stratos
         CF_CLIENT_SECRET: ((stratos-client-secret-production))
   # This is only necessary until we can use variable interpolation in


### PR DESCRIPTION
Running this as part of the pipeline adds traceability to the UI by generating metadata from the git checkout during deploy that can be seen on the About, Diagnostics page, as seen below.
![stratos_-_2018-09-11_19 43 29](https://user-images.githubusercontent.com/723420/45428498-59dbc400-b66f-11e8-86f0-e077eeb9be08.png)
