### PR TITLE
Deployment fixing

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -15,6 +15,7 @@ jobs:
         type: docker-image
         source:
           repository: node
+          tag: 10
       inputs:
       - name: stratos-src
       - name: stratos-config

--- a/manifest.yml
+++ b/manifest.yml
@@ -4,6 +4,7 @@ applications:
     memory: 1512M
     disk_quota: 1024M
     timeout: 180
-    buildpack: https://github.com/cloudfoundry-incubator/stratos-buildpack#v2.4
+    buildpacks:
+      - https://github.com/cloudfoundry-incubator/stratos-buildpack#v2.4
     health-check-type: port
     instances: 3

--- a/manifest.yml
+++ b/manifest.yml
@@ -4,6 +4,6 @@ applications:
     memory: 1512M
     disk_quota: 1024M
     timeout: 180
-    buildpack: https://github.com/cloudfoundry-incubator/stratos-buildpack#v2
+    buildpack: https://github.com/cloudfoundry-incubator/stratos-buildpack#v2.4
     health-check-type: port
     instances: 3


### PR DESCRIPTION
This gets stratos deploying again. The build passes, and the app seems healthy.
The first problem was that the version of node-sass specified by stratos is incompatible with node versions after 10, so I pinned the node docker image to 10. 
Next is picking up the new buildpack, which was required for some go dependencies. 
I also fixed one of the deprecation warnings in the app manifest. 

after getting this built and deployed to staging, I again ran into the problem that I can't log into dev secureauth, so I'm currently blocked on any ad-hoc testing.
