### PR TITLE
Use legacy `buildpack`

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -4,7 +4,6 @@ applications:
     memory: 1512M
     disk_quota: 1024M
     timeout: 180
-    buildpacks:
-      - https://github.com/cloudfoundry-incubator/stratos-buildpack#v2.4
+    buildpack: https://github.com/cloudfoundry-incubator/stratos-buildpack#v2.4
     health-check-type: port
     instances: 3


### PR DESCRIPTION
We're using legacy `host` which forces a legacy push, and `buildpacks` can't be used with legacy push